### PR TITLE
Add Graphing application

### DIFF
--- a/app/components/chart.hbs
+++ b/app/components/chart.hbs
@@ -1,0 +1,7 @@
+<div class="lttf-chart">
+  <div class="flex">
+    <h2>{{this.ruleName}}</h2>
+    <LinkTo @route="files" @model={{@rule}}>view files</LinkTo>
+  </div>
+  <div {{did-insert this.renderChart}}></div>
+</div>

--- a/app/components/chart.js
+++ b/app/components/chart.js
@@ -1,0 +1,77 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+import { Chart } from "frappe-charts/dist/frappe-charts.min.esm";
+
+function normaliseData(data) {
+  console.log(data);
+  let keys = Object.keys(data);
+
+  let output = {};
+
+  let dates = keys.map(key => new Date(key));
+
+  let min = Math.min(...dates);
+  let max = Math.max(...dates);
+
+  let normalisedKeys = [];
+  let currentDate = new Date(min);
+
+  while (currentDate <= max) {
+    normalisedKeys.push(currentDate.toISOString().split('T')[0]);
+
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  let lastValue;
+  normalisedKeys.forEach(key => {
+    if(data[key]) {
+      lastValue = data[key].length
+    }
+    output[key] = lastValue;
+  })
+
+  return output;
+}
+
+export default class ChartComponent extends Component {
+  get plugin() {
+    return this.args.rule.split(':')[0];
+  }
+
+  get ruleName() {
+    return this.args.rule.split(':')[1];
+  }
+
+  @action
+  renderChart(element) {
+    let processedData = normaliseData(this.args.data);
+
+    console.log({processedData});
+
+    const data = {
+        labels: Object.keys(processedData),
+        datasets: [
+            {
+                name: this.ruleName,
+                type: "line",
+                values: Object.values(processedData)
+            }
+        ],
+        yMarkers: [
+            {
+                label: '',
+                value: 0,
+                type: 'solid'
+            }
+        ]
+    }
+
+    this.chart = new Chart(element, {
+        data: data,
+        type: 'axis-mixed', // or 'bar', 'line', 'scatter', 'pie', 'percentage'
+        height: 250,
+        colors: ['#7cd6fd', '#743ee2']
+    })
+  }
+}

--- a/app/router.js
+++ b/app/router.js
@@ -7,4 +7,5 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function() {
+  this.route('files', { path: 'files/:id'});
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,9 +1,11 @@
 import Route from '@ember/routing/route';
 import fetch from 'fetch';
 
+import env from 'lint-to-the-future/config/environment';
+
 export default class ApplicationRoute extends Route {
   async model() {
-    let data = await (await fetch('/data.json')).json();
+    let data = await (await fetch(`${env.rootURL}data.json`)).json();
 
     let results = {};
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,0 +1,27 @@
+import Route from '@ember/routing/route';
+import fetch from 'fetch';
+
+export default class ApplicationRoute extends Route {
+  async model() {
+    let data = await (await fetch('/data.json')).json();
+
+    let results = {};
+
+    Object.keys(data).forEach((date) => {
+      Object.keys(data[date]).forEach((plugin) => {
+        Object.keys(data[date][plugin]).forEach((rule) => {
+          let compoundKey = `${plugin}:${rule}`;
+          if (results[compoundKey]) {
+            results[compoundKey][date] = data[date][plugin][rule];
+          } else {
+            results[compoundKey] = {
+              [date]: data[date][plugin][rule],
+            };
+          }
+        })
+      })
+    });
+
+    return results;
+  }
+}

--- a/app/routes/files.js
+++ b/app/routes/files.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+
+export default class FilesRoute extends Route {
+  model(params) {
+    let application = this.modelFor('application');
+
+    let ruleValue = application[params.id];
+    let keys = Object.keys(ruleValue);
+
+    // the keys are ISO dates, so sorting them alphabetically always sorts them
+    // in date order too :tada:
+    let max = keys.sort((a, b) => a > b)[keys.length - 1];
+
+    // this just returns the most recent list of files
+    return ruleValue[max];
+  }
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,0 +1,11 @@
+body {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(600px, 100%), 1fr));
+  grid-gap: 20px
+}
+
+.flex {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -4,6 +4,22 @@ body {
   grid-gap: 20px
 }
 
+.modal {
+  position: fixed;
+  top: 50px;
+  bottom: 50px;
+  right: 50px;
+  left: 50px;
+
+  border-radius: 25px;
+  padding: 25px;
+  background-color: #eee;
+}
+
+.modal > h1 {
+  margin-top: 0;
+}
+
 .flex {
   display: flex;
   align-items: baseline;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,5 +1,5 @@
-{{!-- The following component displays Ember's default welcome message. --}}
-<WelcomePage />
-{{!-- Feel free to remove this! --}}
+{{#each-in @model as |key value|}}
+  <Chart @rule={{key}} @data={{value}} />
+{{/each-in}}
 
 {{outlet}}

--- a/app/templates/files.hbs
+++ b/app/templates/files.hbs
@@ -1,0 +1,8 @@
+<div class="modal">
+  <h1> Files </h1>
+  <ul>
+    {{#each @model as |file|}}
+      <li>{{file}}</li>
+    {{/each}}
+  </ul>
+</div>

--- a/cli.js
+++ b/cli.js
@@ -1,22 +1,109 @@
 #!/usr/bin/env node
 
 const { join } = require('path');
+const { writeFileSync, readFileSync } = require('fs');
+const { copy } = require('fs-extra');
 const importCwd = require('import-cwd');
+const minimist = require('minimist');
+const fetch = require('node-fetch');
 
-// var resolve = require('resolve').sync;
+const argv = minimist(process.argv.slice(2));
+
+async function list(lttfPlugins) {
+  let pluginResults = {};
+
+  for (let plugin of lttfPlugins) {
+    pluginResults[plugin.name] = await plugin.import.list();
+  }
+
+  let previousResults = {}
+
+  if (argv['previous-results']) {
+    const response = await fetch(argv['previous-results']);
+
+    if(response.ok) {
+      previousResults = await response.json();
+    } else {
+      console.warn(`Error ${response.status} when downloading previous results. Previous results ignored`);
+    }
+  }
+
+  console.log(previousResults);
+
+  let today = new Date();
+  let isoDate = today.toISOString().split('T')[0];
+
+  previousResults[isoDate] = pluginResults;
+
+  return previousResults;
+}
+
+async function output(lttfPlugins) {
+  if (!argv.o) {
+    console.error('You must provide an output directory to `output` with -o');
+  }
+
+  const ouputResult = await list(lttfPlugins);
+
+  await copy(join(__dirname, 'dist'), argv.o);
+
+  if(argv.rootUrl) {
+    let index = readFileSync(join(argv.o, 'index.html'), 'utf8');
+    let regex = /<meta name="lint-to-the-future\/config\/environment" content="(.*)" \/>/;
+    let envContentString = index.match(regex)[1];
+    let envContent =  JSON.parse(decodeURIComponent(envContentString));
+    envContent.rootURL = `/${argv.rootUrl}/`;
+    console.log(envContent);
+    writeFileSync(join(argv.o, 'index.html'), index.replace(regex, `<meta name="lint-to-the-future/config/environment" content="${encodeURIComponent(JSON.stringify(envContent))}" />`), )
+  }
+
+
+
+
+  writeFileSync(join(argv.o, 'data.json'), JSON.stringify(ouputResult));
+}
 
 async function main() {
   let currentPackageJSON = require(join(process.cwd(), 'package.json'));
 
-  let lttfPlugins = [
+  let lttfPluginsNames = [
     ...Object.keys(currentPackageJSON.devDependencies),
     ...Object.keys(currentPackageJSON.dependencies)
   ].filter(dep => dep.startsWith('lint-to-the-future-'));
 
-  for (let pluginName of lttfPlugins) {
-    let plugin = importCwd(pluginName);
+  let lttfPlugins = lttfPluginsNames.map(name => ({
+    import: importCwd(name),
+    name,
+  }));
 
-    await plugin.ignoreAll();
+  switch (argv._[0]) {
+    case 'output':
+      await output(lttfPlugins);
+
+      break;
+
+    case 'list':
+      if (!argv.o && !argv.stdout) {
+        console.error('You must provide an output path to `list` with -o or pass --stdout');
+      }
+
+      // eslint-disable-next-line
+      const listResult = await list(lttfPlugins);
+
+      if (argv.stdout) {
+        console.log(listResult);
+      }
+
+      if (argv.o) {
+        writeFileSync(argv.o, JSON.stringify(listResult));
+      }
+
+      break;
+    case 'ignore':
+    default:
+      for (let plugin of lttfPlugins) {
+        await plugin.import.ignoreAll();
+      }
   }
 }
 

--- a/cli.js
+++ b/cli.js
@@ -54,11 +54,13 @@ async function output(lttfPlugins) {
     let envContent =  JSON.parse(decodeURIComponent(envContentString));
     envContent.rootURL = `/${argv.rootUrl}/`;
     console.log(envContent);
-    writeFileSync(join(argv.o, 'index.html'), index.replace(regex, `<meta name="lint-to-the-future/config/environment" content="${encodeURIComponent(JSON.stringify(envContent))}" />`), )
+    writeFileSync(
+      join(argv.o, 'index.html'),
+      index
+        .replace(regex, `<meta name="lint-to-the-future/config/environment" content="${encodeURIComponent(JSON.stringify(envContent))}" />`)
+        .replace(/"\/assets\//g, `"/${argv.rootUrl}/assets/`),
+    );
   }
-
-
-
 
   writeFileSync(join(argv.o, 'data.json'), JSON.stringify(ouputResult));
 }

--- a/config/targets.js
+++ b/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions'
 ];
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "lint-to-the-future",
-  "version": "0.3.1",
+  "version": "0.4.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.1",
+      "version": "0.4.0-0",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,17 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "import-cwd": "^3.0.0"
+        "fs-extra": "^7.0.1",
+        "import-cwd": "^3.0.0",
+        "minimist": "^1.2.5",
+        "node-fetch": "^2.6.0"
       },
       "bin": {
         "lint-to-the-future": "cli.js"
       },
       "devDependencies": {
         "@ember/optional-features": "^1.3.0",
+        "@ember/render-modifiers": "^1.0.2",
         "@glimmer/component": "^1.0.0",
         "@glimmer/tracking": "^1.0.0",
         "babel-eslint": "^10.1.0",
@@ -41,6 +45,7 @@
         "eslint": "^6.8.0",
         "eslint-plugin-ember": "^8.4.0",
         "eslint-plugin-node": "^11.1.0",
+        "frappe-charts": "^1.5.2",
         "loader.js": "^4.7.0",
         "npm-run-all": "^4.1.5",
         "qunit-dom": "^1.2.0"
@@ -3357,6 +3362,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "object-assign": "4.1.1"
+      }
+    },
+    "node_modules/@ember/render-modifiers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz",
+      "integrity": "sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-modifier-manager-polyfill": "^1.1.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/@ember/test-helpers": {
@@ -12759,6 +12777,33 @@
         "object-assign": "4.1.1"
       }
     },
+    "node_modules/ember-modifier-manager-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
+      "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "ember-compatibility-helpers": "^1.2.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-modifier-manager-polyfill/node_modules/ember-cli-version-checker": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.3.3",
+        "semver": "^5.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/ember-qunit": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-4.6.0.tgz",
@@ -15563,6 +15608,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/frappe-charts": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/frappe-charts/-/frappe-charts-1.5.5.tgz",
+      "integrity": "sha512-L9pJTsrSuRobS/EaBKT8i1x+DVOjkXyUwT85cteZAPqynU/7K+uqjQOy4tMSTv5zsTWJNWFJ37ax68T73YdR3g==",
+      "dev": true
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -15621,7 +15672,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -16133,7 +16183,6 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graceful-readlink": {
@@ -17595,7 +17644,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.6"
@@ -18611,7 +18659,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/minipass": {
@@ -18850,7 +18897,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "4.x || >=6.0.0"
@@ -23944,7 +23990,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -27691,6 +27736,16 @@
             "object-assign": "4.1.1"
           }
         }
+      }
+    },
+    "@ember/render-modifiers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz",
+      "integrity": "sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-modifier-manager-polyfill": "^1.1.0"
       }
     },
     "@ember/test-helpers": {
@@ -35250,6 +35305,29 @@
         }
       }
     },
+    "ember-modifier-manager-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
+      "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "ember-compatibility-helpers": "^1.2.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        }
+      }
+    },
     "ember-qunit": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-4.6.0.tgz",
@@ -37320,6 +37398,12 @@
         "map-cache": "^0.2.2"
       }
     },
+    "frappe-charts": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/frappe-charts/-/frappe-charts-1.5.5.tgz",
+      "integrity": "sha512-L9pJTsrSuRobS/EaBKT8i1x+DVOjkXyUwT85cteZAPqynU/7K+uqjQOy4tMSTv5zsTWJNWFJ37ax68T73YdR3g==",
+      "dev": true
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -37372,7 +37456,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -37757,8 +37840,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -38830,7 +38912,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -39641,8 +39722,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.9.0",
@@ -39830,8 +39910,7 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -43702,8 +43781,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "lint-to-the-future",
-  "version": "0.4.0-0",
+  "version": "0.4.0-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.0-0",
+      "version": "0.4.0-1",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lint-to-the-future",
-  "version": "0.4.0-0",
+  "version": "0.4.0-1",
   "description": "A modern way to progressively update your code to the best practices",
   "repository": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "tests"
   },
   "files": [
-    "cli.js"
+    "cli.js",
+    "dist"
   ],
   "scripts": {
     "build": "ember build --environment=production",
@@ -22,7 +23,8 @@
     "lint:js": "eslint .",
     "start": "ember serve",
     "test": "npm-run-all lint:* test:*",
-    "test:ember": "ember test"
+    "test:ember": "ember test",
+    "prepublishOnly": "rm -rf dist && npm run build"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
@@ -68,6 +70,9 @@
     "edition": "octane"
   },
   "dependencies": {
-    "import-cwd": "^3.0.0"
+    "fs-extra": "^7.0.1",
+    "import-cwd": "^3.0.0",
+    "minimist": "^1.2.5",
+    "node-fetch": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lint-to-the-future",
-  "version": "0.3.1",
+  "version": "0.4.0-0",
   "description": "A modern way to progressively update your code to the best practices",
   "repository": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
+    "@ember/render-modifiers": "^1.0.2",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
     "babel-eslint": "^10.1.0",
@@ -52,6 +53,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^8.4.0",
     "eslint-plugin-node": "^11.1.0",
+    "frappe-charts": "^1.5.2",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "qunit-dom": "^1.2.0"


### PR DESCRIPTION
this finally implements the point of lint-to-the-future 🎉 allows you to to "output" an application that keeps track of the linting rules that you need to work on and see as you're progression with graphs! 

![localhost_4200_ (1)](https://user-images.githubusercontent.com/594890/102280913-e4ce5780-3f25-11eb-82c7-1db47b8995c7.png)

I've released it as a pre-minor so we can test it in CI somewhere and see if it actually works 😱 

Here is the command line I was testing with: 

```
npx lint-to-the-future output -o output/sub --rootUrl sub --previous-results http://127.0.0.1:8080/data.json
```

adding here because this PR doesn't have any documentation yet