### PR TITLE
remove incorrect peer-dependency on eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,6 @@
     "qunit-dom": "^1.2.0",
     "release-it": "^14.6.1"
   },
-  "peerDependencies": {
-    "eslint": "^6.0.0 || ^7.0.0"
-  },
   "engines": {
     "node": "10.* || >= 12"
   },


### PR DESCRIPTION
now that eslint has been moved to the lint-to-the-future-eslint plugin it doesn't need to be a peer-dependency any more 👍 