### PR TITLE
Move from minimist to commander

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -47,31 +47,31 @@ async function list(lttfPlugins, previousResultsPath) {
   return previousResults;
 }
 
-async function output(lttfPlugins) {
-  if (!argv.o) {
+async function output(lttfPlugins, outputPath, rootUrl, previousResultsPath) {
+  if (!output) {
     console.error('You must provide an output directory to `output` with -o');
   }
 
-  const ouputResult = await list(lttfPlugins);
+  const ouputResult = await list(lttfPlugins, previousResultsPath);
 
-  await copy(join(__dirname, 'dist'), argv.o);
+  await copy(join(__dirname, 'dist'), outputPath);
 
-  if(argv.rootUrl) {
-    let index = readFileSync(join(argv.o, 'index.html'), 'utf8');
+  if(rootUrl) {
+    let index = readFileSync(join(outputPath, 'index.html'), 'utf8');
     let regex = /<meta name="lint-to-the-future\/config\/environment" content="(.*)" \/>/;
     let envContentString = index.match(regex)[1];
     let envContent =  JSON.parse(decodeURIComponent(envContentString));
-    envContent.rootURL = `/${argv.rootUrl}/`;
+    envContent.rootURL = `/${rootUrl}/`;
     console.log(envContent);
     writeFileSync(
-      join(argv.o, 'index.html'),
+      join(outputPath, 'index.html'),
       index
         .replace(regex, `<meta name="lint-to-the-future/config/environment" content="${encodeURIComponent(JSON.stringify(envContent))}" />`)
-        .replace(/"\/assets\//g, `"/${argv.rootUrl}/assets/`),
+        .replace(/"\/assets\//g, `"/${rootUrl}/assets/`),
     );
   }
 
-  writeFileSync(join(argv.o, 'data.json'), JSON.stringify(ouputResult));
+  writeFileSync(join(outputPath, 'data.json'), JSON.stringify(ouputResult));
 }
 
 async function main() {
@@ -103,7 +103,7 @@ async function main() {
 
   switch (argv._[0]) {
     case 'output':
-      await output(lttfPlugins);
+      await output(lttfPlugins, argv.o, argv.rootUrl, argv['previous-results']);
 
       break;
 

--- a/cli.js
+++ b/cli.js
@@ -74,7 +74,7 @@ async function output(lttfPlugins, outputPath, rootUrl, previousResultsPath) {
   writeFileSync(join(outputPath, 'data.json'), JSON.stringify(ouputResult));
 }
 
-async function main() {
+async function getLttfPlugins() {
   let currentPackageJSON = require(join(process.cwd(), 'package.json'));
 
   let lttfPluginsNames = [
@@ -100,6 +100,11 @@ async function main() {
       name,
     })
   }
+  return lttfPlugins;
+}
+
+async function main() {
+  let lttfPlugins = await getLttfPlugins();
 
   switch (argv._[0]) {
     case 'output':

--- a/cli.js
+++ b/cli.js
@@ -36,8 +36,6 @@ async function list(lttfPlugins, previousResultsPath) {
     }
   }
 
-  console.log(previousResults);
-
   let today = new Date();
   let isoDate = today.toISOString().split('T')[0];
 
@@ -61,7 +59,6 @@ async function output(lttfPlugins, outputPath, rootUrl, previousResultsPath) {
     let envContentString = index.match(regex)[1];
     let envContent =  JSON.parse(decodeURIComponent(envContentString));
     envContent.rootURL = `/${rootUrl}/`;
-    console.log(envContent);
     writeFileSync(
       join(outputPath, 'index.html'),
       index

--- a/cli.js
+++ b/cli.js
@@ -6,6 +6,7 @@ const { copy } = require('fs-extra');
 const importCwd = require('import-cwd');
 const fetch = require('node-fetch');
 const { Command } = require('commander');
+const { inspect } = require('util');
 const program = new Command();
 
 async function list(lttfPlugins, previousResultsPath) {
@@ -125,12 +126,12 @@ program
     if (!outputPath && !stdout) {
       console.error('You must provide an output path to `list` with -o or pass --stdout');
     }
-  
+
     let lttfPlugins = await getLttfPlugins();
     const listResult = await list(lttfPlugins, previousResults);
 
     if (stdout) {
-      console.log(listResult);
+      console.log(inspect(listResult, { depth: 5 }));
     }
 
     if (outputPath) {

--- a/cli.js
+++ b/cli.js
@@ -9,7 +9,7 @@ const fetch = require('node-fetch');
 
 const argv = minimist(process.argv.slice(2));
 
-async function list(lttfPlugins) {
+async function list(lttfPlugins, previousResultsPath) {
   let pluginResults = {};
 
   for (let plugin of lttfPlugins) {
@@ -18,10 +18,9 @@ async function list(lttfPlugins) {
 
   let previousResults = {}
 
-  if (argv['previous-results']) {
-    let previousResultsLocation = argv['previous-results'];
-    if (previousResultsLocation.match(/((http(s?)):\/\/)/)) {
-      const response = await fetch(argv['previous-results']);
+  if (previousResultsPath) {
+    if (previousResultsPath.match(/((http(s?)):\/\/)/)) {
+      const response = await fetch(previousResultsPath);
 
       if(response.ok) {
         previousResults = await response.json();
@@ -30,10 +29,10 @@ async function list(lttfPlugins) {
       }
     } else {
       try {
-        let file = readFileSync(previousResultsLocation);
+        let file = readFileSync(previousResultsPath);
         previousResults = JSON.parse(file);
       } catch {
-        console.warn(`Error ${previousResultsLocation} could not be found. Previous results ignored`);
+        console.warn(`Error ${previousResultsPath} could not be found. Previous results ignored`);
       }
     }
   }
@@ -114,7 +113,7 @@ async function main() {
       }
 
       // eslint-disable-next-line
-      const listResult = await list(lttfPlugins);
+      const listResult = await list(lttfPlugins, argv['previous-results']);
 
       if (argv.stdout) {
         console.log(listResult);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
+        "commander": "^9.4.1",
         "fs-extra": "^7.0.1",
         "import-cwd": "^3.0.0",
-        "minimist": "^1.2.5",
         "node-fetch": "^2.6.0"
       },
       "bin": {
@@ -6016,6 +6016,15 @@
         "node": ">=8.3"
       }
     },
+    "node_modules/auto-changelog/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -9590,12 +9599,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true,
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
       "engines": {
-        "node": ">= 6"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/common-tags": {
@@ -19893,7 +19901,8 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "node_modules/minipass": {
       "version": "3.1.5",
@@ -32271,6 +32280,14 @@
         "p-map": "^4.0.0",
         "parse-github-url": "^1.0.2",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        }
       }
     },
     "babel-code-frame": {
@@ -35404,10 +35421,9 @@
       }
     },
     "commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
     },
     "common-tags": {
       "version": "1.8.0",
@@ -43761,7 +43777,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minipass": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -75,9 +75,9 @@
     "edition": "octane"
   },
   "dependencies": {
+    "commander": "^9.4.1",
     "fs-extra": "^7.0.1",
     "import-cwd": "^3.0.0",
-    "minimist": "^1.2.5",
     "node-fetch": "^2.6.0"
   },
   "ember-addon": {


### PR DESCRIPTION
This PR updates Lint To The Future to use `Commander` instead of `Minimist`. The key benefits being that it provides you with in built guards to commands and options and also produces `--help` information when using the cli tool.

This is best reviewed by commit to help make the changes clear and if required the initial 3 commits can be a separate PR.

