### PR TITLE
handle invalid JSON from previousResults

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -22,8 +22,14 @@ async function list(lttfPlugins, previousResultsPath) {
     if (previousResultsPath.match(/((http(s?)):\/\/)/)) {
       const response = await fetch(previousResultsPath);
 
-      if(response.ok) {
-        previousResults = await response.json();
+      if (response.ok) {
+        try {
+          previousResults = await response.json();
+        } catch (e) {
+          console.warn(
+            `Error (${e.message}) when parsing previous results. Previous results ignored`
+          );
+        }
       } else {
         console.warn(`Error ${response.status} when downloading previous results. Previous results ignored`);
       }


### PR DESCRIPTION
The goal of this MR is for the CLI to be able to recover from previousResult URL returning a 200 but with an invalid JSON.