### PR TITLE
add lttf alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "author": "Chris Manson <chris@manson.ie>",
   "bin": {
-    "lint-to-the-future": "cli.js"
+    "lint-to-the-future": "cli.js",
+    "lttf": "cli.js"
   },
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
now you can run `npx lttf ignore` when this is installed locally 😍 