### PR TITLE
Hide completed rules

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,0 +1,17 @@
+import Controller from '@ember/controller';
+
+export default class ApplicationController extends Controller {
+  get rules() {
+    let rulesToComplete = {};
+    let completedRules = {};
+    for (let key in this.model.data) {
+      let rule = this.model.data[key];
+      if (rule[this.model.highestDate]) {
+        rulesToComplete[key] = rule;
+      } else {
+        completedRules[key] = rule;
+      }
+    }
+    return { rulesToComplete, completedRules };
+  }
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,3 +1,5 @@
+/* stylelint-disable prettier/prettier, rule-empty-line-before, color-function-notation, declaration-block-no-shorthand-property-overrides, alpha-value-notation */
+/* stylelint-disable declaration-block-no-redundant-longhand-properties */
 body {
   background-color: #EDF7D2;
   font-family: 'Source Sans Pro', sans-serif;
@@ -34,7 +36,6 @@ a {
   bottom: 50px;
   right: 50px;
   left: 50px;
-
   border-radius: 25px;
   padding: 0 25px 25px;
   background-color: white;
@@ -121,4 +122,20 @@ footer {
 /* This is a hack to remove the y-markers that are designed to remove fractional numbers from the axis */
 .frappe-chart .y-markers {
   display: none;
+}
+
+details {
+  margin: 20px 0;
+  border: #0F3460 3px solid;
+}
+
+summary {
+  background-color: #16213E;
+  color: white;
+  cursor: pointer;
+  padding: 20px;
+}
+
+details[open] summary {
+  margin-bottom: 20px;
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,9 +1,19 @@
 <h1>Lint to the Future Dashboard</h1>
 <div class="graphs">
-  {{#each-in @model.data as |key value|}}
+  {{#each-in this.rules.rulesToComplete as |key value|}}
     <Chart @rule={{key}} @data={{value}} @highestDate={{@model.highestDate}} />
   {{/each-in}}
 </div>
+
+
+<details data-test-completed-rules>
+  <summary>Completed Rules</summary>
+  <div class="graphs">
+    {{#each-in this.rules.completedRules as |key value|}}
+      <Chart @rule={{key}} @data={{value}} @highestDate={{@model.highestDate}} />
+    {{/each-in}}
+  </div>
+</details>
 
 <footer>
   This page was generated with <a href="https://github.com/mansona/lint-to-the-future">Lint to the Future</a> which was built with ❤️ by <a href="https://twitter.com/real_ate">Chris Manson</a>

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -21,4 +21,14 @@ module('Acceptance | basic', function(hooks) {
     assert.equal(currentURL(), '/files/lint-to-the-future-eslint:prettier%2Fprettier');
     assert.dom('[data-test-file]').exists({count: 32})
   });
+
+  test('completed rules are filtered into collapsed window', async function (assert) {
+    await visit('/');
+
+
+    assert.equal(currentURL(), '/');
+    assert.dom('[data-test-chart]').exists({count: 9})
+
+    assert.dom('[data-test-completed-rules] [data-test-chart]').exists({count: 1});
+  })
 });

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -25,9 +25,9 @@ module('Acceptance | basic', function(hooks) {
   test('completed rules are filtered into collapsed window', async function (assert) {
     await visit('/');
 
-
     assert.equal(currentURL(), '/');
-    assert.dom('[data-test-chart]').exists({count: 9})
+    // top level charts
+    assert.dom('.ember-application > div > [data-test-chart]').exists({count: 9})
 
     assert.dom('[data-test-completed-rules] [data-test-chart]').exists({count: 1});
   })


### PR DESCRIPTION
ive added a filter that hides rules that have been `completed` (rules that have 0 cases), they are hidden in an accordion. Please confirm the logic is correct. 

