### PR TITLE
make sure that we never pass a filter to a plugin that doesn't support it

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -163,14 +163,16 @@ program
   .action(async (options) => {
 
     function executePlugin(plugin) {
-      if (options.filter) {
-        if (!plugin.import.capabilities?.includes('filter-ignore')) {
+      // this makes sure that even when
+      if (plugin.import.capabilities?.includes('filter-ignore')) {
+        return plugin.import.ignoreAll({filter: options.filter});
+      } else {
+        if (options.filter) {
           program.error(`Plugin ${plugin.name} does not support passing '--filter' to the ignore command. Please update or contact the plugin developers`);
           return;
         }
+        plugin.import.ignoreAll()
       }
-
-      return plugin.import.ignoreAll({filter: options.filter});
     }
 
     let lttfPlugins = await getLttfPlugins();

--- a/node-tests/ignore-command.mjs
+++ b/node-tests/ignore-command.mjs
@@ -36,9 +36,9 @@ describe('remove command', function () {
 
     project.addDependency('lint-to-the-future-old-plugin', {
       files: {
-        'index.js': `function ignoreAll() {
+        'index.js': `function ignoreAll(someUnknownParam = "old-plugin") {
           // we need to communicate via stdout since we're calling this via a different process
-          console.log('ignoredAll from old-plugin');
+          console.log(\`ignoredAll from \${someUnknownParam}\`);
         }
         module.exports = {
           ignoreAll,


### PR DESCRIPTION
In my previous attempt at this implementation I successfully warned when people were trying to pass a filter to a plugin that doesn't support it, but I accidentally passed an empty object as a parameter to the ignore function which could be breaking