### PR TITLE
fix issues with light mode completed rules section

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,13 +1,25 @@
 /* stylelint-disable prettier/prettier, rule-empty-line-before, color-function-notation, declaration-block-no-shorthand-property-overrides, alpha-value-notation */
 /* stylelint-disable declaration-block-no-redundant-longhand-properties */
+
+:root {
+  --light-link-color: #5C8001;
+  --chart-border-radius: 8px;
+}
+
 body {
   background-color: #EDF7D2;
   font-family: 'Source Sans Pro', sans-serif;
   margin: 20px;
 }
+
 a {
-  color: #5C8001;
+  color: var(--light-link-color);
 }
+
+.plain-link {
+  color: black;
+}
+
 .graphs {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(min(600px, 100%), 1fr));
@@ -16,7 +28,7 @@ a {
 
 .lttf-chart {
   background-color: white;
-  border-radius: 8px;
+  border-radius: var(--chart-border-radius);
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
   padding: 20px;
 }
@@ -92,11 +104,34 @@ a {
   background-color: #3277b3;
 }
 
+details {
+  margin: 20px 0;
+  border: var(--light-link-color) 1px solid;
+}
+
+summary {
+  cursor: pointer;
+  padding: 20px;
+}
+
+details > .graphs {
+  margin-bottom: 20px;
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     background-color: #1A1A2E;
     color: white;
   }
+
+  .plain-link {
+    color: white
+  }
+
+  details {
+    border-color: #0F3460;
+  }
+
   a {
     color: #FBBF24;
   }
@@ -113,6 +148,10 @@ a {
   svg.close path {
     fill: white;
   }
+
+  summary {
+    color: white;
+  }
 }
 
 footer {
@@ -122,20 +161,4 @@ footer {
 /* This is a hack to remove the y-markers that are designed to remove fractional numbers from the axis */
 .frappe-chart .y-markers {
   display: none;
-}
-
-details {
-  margin: 20px 0;
-  border: #0F3460 3px solid;
-}
-
-summary {
-  background-color: #16213E;
-  color: white;
-  cursor: pointer;
-  padding: 20px;
-}
-
-details[open] summary {
-  margin-bottom: 20px;
 }


### PR DESCRIPTION
So it looks like https://github.com/mansona/lint-to-the-future/pull/47 was designed in dark mode with only dark mode in mind 😂 

This PR adds some basic design improvements and fixes the overall look and feel for light mode

## Before This PR: 

Light Mode: 

![lint-to-the-future-demo netlify app_](https://github.com/user-attachments/assets/30d8c93e-b9ce-46a2-a4b2-c4addd581900)

![lint-to-the-future-demo netlify app_ (1)](https://github.com/user-attachments/assets/dc2595eb-882f-4749-99f9-a1421d33e095)

Dark Mode: 

![lint-to-the-future-demo netlify app_ (3)](https://github.com/user-attachments/assets/99dea464-cef8-4b9a-985f-76339436b685)

![lint-to-the-future-demo netlify app_ (2)](https://github.com/user-attachments/assets/ef9025b8-1fea-436b-bbbc-021d906ca45d)

## After This PR (you can see in the preview link)

Light Mode: 

![deploy-preview-57--lint-to-the-future-demo netlify app_ (2)](https://github.com/user-attachments/assets/883c18cd-30b8-4e04-b3f9-37f41f93b709)

![deploy-preview-57--lint-to-the-future-demo netlify app_ (3)](https://github.com/user-attachments/assets/78c8521d-56c0-47b7-8e75-bdc46a5660e9)

Dark Mode: 

![deploy-preview-57--lint-to-the-future-demo netlify app_](https://github.com/user-attachments/assets/744bb269-20c4-4c7e-89e8-5e183e993fc1)

![deploy-preview-57--lint-to-the-future-demo netlify app_ (1)](https://github.com/user-attachments/assets/afdb7dd1-bf54-47e6-b4d0-5d47b8c31eff)


